### PR TITLE
Set targets to fix "Module not loadable on target mobile" warnings

### DIFF
--- a/extension.json
+++ b/extension.json
@@ -40,6 +40,7 @@
 	},
 	"ResourceModules": {
 		"ext.imageSuggestions": {
+			"targets": [ "desktop", "mobile" ],
 			"dependencies": [],
 			"messages": [],
 			"styles": [],


### PR DESCRIPTION
Hey @matthiasmullie can you take a look at this? Not sure what this module is for, but it's showing up in error logs as part of https://phabricator.wikimedia.org/T324723.

Thanks in advance!
